### PR TITLE
Fix undefined index in brainfuck interpreter

### DIFF
--- a/brain.php
+++ b/brain.php
@@ -57,7 +57,7 @@
 
     $size = 30000;
     $memory = array_fill(0, $size, 0);
-    $brain = $_POST['brain'];
+    $brain = isset($_POST['brain']) ? $_POST['brain'] : '';
     echo "Brain: $brain <br>";
     $loops = array();
     $current = 0;


### PR DESCRIPTION
## Summary
- avoid PHP notice when `$_POST['brain']` is not set

## Testing
- `php -l brain.php`

------
https://chatgpt.com/codex/tasks/task_b_68829a25ee34832984fc0eef73ea0fad